### PR TITLE
Add the ability to pass github credentials in to downstream builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM golang:1.10-alpine
 
 ARG GLIBC_VERSION=2.25-r0
 ARG PROTOC_VERSION=3.5.1
-ARG GIT_CREDS
 
 # Install tools of general use
 RUN apk add --no-cache su-exec curl bash git openssh mercurial make ca-certificates expect docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.10-alpine
 
 ARG GLIBC_VERSION=2.25-r0
 ARG PROTOC_VERSION=3.5.1
+ARG GIT_CREDS
 
 # Install tools of general use
 RUN apk add --no-cache su-exec curl bash git openssh mercurial make ca-certificates expect docker
@@ -68,4 +69,12 @@ RUN echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
 COPY create-zenkit.sh /usr/local/bin/create-zenkit.sh
 COPY create-zenkit-local.sh /usr/local/bin/create-zenkit-local.sh
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+ONBUILD ARG GIT_CREDS
+ONBUILD RUN if [ -n "${GIT_CREDS}" ]; then \
+	echo "${GIT_CREDS}" > /etc/.git_creds; \
+	git config --global credential.helper 'store --file /etc/.git_creds'; \
+	git config --global url.'https://github.com'.insteadOf 'ssh://git@github.com'; \
+	fi
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,9 +69,10 @@ COPY create-zenkit.sh /usr/local/bin/create-zenkit.sh
 COPY create-zenkit-local.sh /usr/local/bin/create-zenkit-local.sh
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-ONBUILD ARG GIT_CREDS
-ONBUILD RUN if [ -n "${GIT_CREDS}" ]; then \
-	echo "${GIT_CREDS}" > /etc/.git_creds; \
+ONBUILD ARG GITHUB_USERNAME
+ONBUILD ARG GITHUB_PASSWORD
+ONBUILD RUN if [ -n "${GITHUB_USERNAME}" ]; then \
+	printf 'https://%s:%s@github.com' "${GITHUB_USERNAME}" "${GITHUB_PASSWORD}" > /etc/.git_creds; \
 	git config --global credential.helper 'store --file /etc/.git_creds'; \
 	git config --global url.'https://github.com'.insteadOf 'ssh://git@github.com'; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.7.1
+VERSION := 1.7.2
 
 default: zenoss/zenkit-build
 


### PR DESCRIPTION
This allows you to make a Dockerfile like:
```
FROM zenoss/zenkit-build:1.7.2
RUN git clone https://github.com/zenoss/private-repo
RUN do_stuff
FROM alpine
COPY --from=0 /stuff/that/built /usr/src/app
...
```
And then build it with:
```
docker build --build-arg GITHUB_USERNAME=user --build-arg GITHUB_PASSWORD=password
```

This should only be used with multi-stage builds, or else the creds will be in the image history.